### PR TITLE
Fix yml alignment of `render-readme.yaml`

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -10,23 +10,23 @@ name: Render README
 
 jobs:
   render:
-  name: Render README
-runs-on: macOS-latest
-steps:
-  - uses: actions/checkout@v2
-- uses: r-lib/actions/setup-r@v1
-- uses: r-lib/actions/setup-pandoc@v1
-- name: Install pak, and the local package
-run: |
-  install.packages("pak")
-  pak::local_install(".")
-  pak::pak("rmarkdown")
-shell: Rscript {0}
-- name: Render README
-run: Rscript -e 'rmarkdown::render("README.Rmd")'
-- name: Commit results
-run: |
-  git config --local user.email "actions@github.com"
-git config --local user.name "GitHub Actions"
-git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
-git push origin || echo "No changes to commit"
+    name: Render README
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Install pak, and the local package
+        run: |
+          install.packages("pak")
+          pak::local_install(".")
+          pak::pak("rmarkdown")
+        shell: Rscript {0}
+      - name: Render README
+        run: Rscript -e 'rmarkdown::render("README.Rmd")'
+      - name: Commit results
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"


### PR DESCRIPTION
I originally copied this file directly from a different workflow, and I guess somehow the yaml alignment must have got garbled? Not totally sure how that's possible but anyway...