### PR TITLE
manually add methodology articles to the menu

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,5 +27,12 @@ navbar:
         href: https://rmi-pacta.github.io/pacta.executive.summary/
       - text: "pacta.interactive.plot"
         href: https://rmi-pacta.github.io/pacta.interactive.plot/
+    methodology:
+      text: "Methodology"
+      menu:
+      - text: "Share ownership weight attribution method"
+        href: https://rmi-pacta.github.io/pacta.data.preparation/articles/share_ownership_methodology.html
+      - text: "Transition Disruption Metric"
+        href: https://rmi-pacta.github.io/pacta.portfolio.allocate/articles/transition_disruption_metric.html
 
 url: https://rmi-pacta.github.io/pactaverse


### PR DESCRIPTION
Until we find a more automated way, might as well manually add links to our methodology "articles".